### PR TITLE
Define expression that `Amount` class takes in.

### DIFF
--- a/src/main/java/seedu/finance/logic/commands/SpendCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SpendCommand.java
@@ -28,7 +28,7 @@ public class SpendCommand extends Command {
             + "[" + PREFIX_CATEGORY + "CATEGORY]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
-            + PREFIX_AMOUNT + "123 "
+            + PREFIX_AMOUNT + "$123.23 "
             + PREFIX_DATE + "12/02/2002 "
             + PREFIX_CATEGORY + "Food ";
 

--- a/src/main/java/seedu/finance/model/record/Amount.java
+++ b/src/main/java/seedu/finance/model/record/Amount.java
@@ -10,9 +10,9 @@ import static seedu.finance.commons.util.AppUtil.checkArgument;
  */
 public class Amount {
 
-    public static final String MESSAGE_CONSTRAINTS = "Amounts is a positive numbers, " +
+    public static final String MESSAGE_CONSTRAINTS = "Amount starts with dollar sign and is a positive numbers, " +
             "with either 2 decimal place or none";
-    public static final String VALIDATION_REGEX = "(([1-9]\\d{0,2}(,\\d{3})*)|(([1-9]\\d*)?\\d))(\\.\\d\\d)?$";
+    public static final String VALIDATION_REGEX = "^\\$(([1-9]\\d{0,2}(,\\d{3})*)|(([1-9]\\d*)?\\d))(\\.\\d\\d)?$";
 
     public final String value;
 

--- a/src/main/java/seedu/finance/model/record/Amount.java
+++ b/src/main/java/seedu/finance/model/record/Amount.java
@@ -10,8 +10,9 @@ import static seedu.finance.commons.util.AppUtil.checkArgument;
  */
 public class Amount {
 
-    public static final String MESSAGE_CONSTRAINTS = "Amounts must be positive numbers";
-    public static final String VALIDATION_REGEX = "-?\\d+(\\.\\d+)?";
+    public static final String MESSAGE_CONSTRAINTS = "Amounts is a positive numbers, " +
+            "with either 2 decimal place or none";
+    public static final String VALIDATION_REGEX = "(([1-9]\\d{0,2}(,\\d{3})*)|(([1-9]\\d*)?\\d))(\\.\\d\\d)?$";
 
     public final String value;
 

--- a/src/main/java/seedu/finance/model/record/Amount.java
+++ b/src/main/java/seedu/finance/model/record/Amount.java
@@ -10,8 +10,8 @@ import static seedu.finance.commons.util.AppUtil.checkArgument;
  */
 public class Amount {
 
-    public static final String MESSAGE_CONSTRAINTS = "Amount starts with dollar sign and is a positive numbers, " +
-            "with either 2 decimal place or none";
+    public static final String MESSAGE_CONSTRAINTS = "Amount starts with dollar sign and is a positive numbers, "
+            + "with either 2 decimal place or none";
     public static final String VALIDATION_REGEX = "^\\$(([1-9]\\d{0,2}(,\\d{3})*)|(([1-9]\\d*)?\\d))(\\.\\d\\d)?$";
 
     public final String value;

--- a/src/main/java/seedu/finance/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/finance/model/util/SampleDataUtil.java
@@ -21,17 +21,17 @@ public class SampleDataUtil {
     public static final String STANDARD_DESCRIPTION = "some description";
     public static Record[] getSampleRecords() {
         return new Record[] {
-            new Record(new Name("Weekly groceries purchase"), new Amount("100"), new Date("12/02/2018"),
+            new Record(new Name("Weekly groceries purchase"), new Amount("$100"), new Date("12/02/2018"),
                 new Description(STANDARD_DESCRIPTION), getCategorySet("Shopping")),
-            new Record(new Name("H and M Clothes"), new Amount("100"), new Date("12/02/2018"),
+            new Record(new Name("H and M Clothes"), new Amount("$100"), new Date("12/02/2018"),
                 new Description(STANDARD_DESCRIPTION), getCategorySet("Shopping")),
-            new Record(new Name("Chicken Rice lunch"), new Amount("100"), new Date("12/02/2018"),
+            new Record(new Name("Chicken Rice lunch"), new Amount("$100"), new Date("12/02/2018"),
                 new Description(STANDARD_DESCRIPTION), getCategorySet("Food")),
-            new Record(new Name("Haircut"), new Amount("100"), new Date("12/02/2018"),
+            new Record(new Name("Haircut"), new Amount("$100"), new Date("12/02/2018"),
                 new Description(STANDARD_DESCRIPTION), getCategorySet("entertainment")),
-            new Record(new Name("Bus Ride"), new Amount("100"), new Date("12/02/2018"),
+            new Record(new Name("Bus Ride"), new Amount("$100"), new Date("12/02/2018"),
                 new Description(STANDARD_DESCRIPTION), getCategorySet("Transportation")),
-            new Record(new Name("Cigarettes"), new Amount("100"), new Date("12/02/2018"),
+            new Record(new Name("Cigarettes"), new Amount("$100"), new Date("12/02/2018"),
                 new Description(STANDARD_DESCRIPTION), getCategorySet("vices"))
         };
     }

--- a/src/test/data/JsonSerializableFinanceTrackerTest/duplicateRecordFinanceTracker.json
+++ b/src/test/data/JsonSerializableFinanceTrackerTest/duplicateRecordFinanceTracker.json
@@ -1,13 +1,13 @@
 {
   "records": [ {
     "name": "Fries",
-    "amount" : "3.00",
+    "amount" : "$3.00",
     "date" : "03/02/2019",
     "description": "some description",
     "category": [ "friends" ]
   }, {
     "name": "Fries",
-    "amount" : "3.00",
+    "amount" : "$3.00",
     "date" : "12/03/2019",
     "description": "some description"
   } ]

--- a/src/test/data/JsonSerializableFinanceTrackerTest/typicalRecordsFinanceTracker.json
+++ b/src/test/data/JsonSerializableFinanceTrackerTest/typicalRecordsFinanceTracker.json
@@ -2,7 +2,7 @@
   "_comment": "FinanceTracker saves file which contains the same Record values as in TypicalRecords#getTypicalFinanceTracker()",
   "records" : [ {
     "name" : "Alice Pauline",
-    "amount" : "120",
+    "amount" : "120.30",
     "date" : "12/02/2017",
     "description": "",
     "tagged" : [ "friends" ]
@@ -14,7 +14,7 @@
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
-    "amount" : "130",
+    "amount" : "130.45",
     "date" : "12/05/2017",
     "description": "",
     "tagged" : [ ]
@@ -38,7 +38,7 @@
     "tagged" : [ ]
   }, {
     "name" : "George Best",
-    "amount" : "128",
+    "amount" : "128.90",
     "date" : "12/02/2027",
     "description": "",
     "tagged" : [ ]

--- a/src/test/data/JsonSerializableFinanceTrackerTest/typicalRecordsFinanceTracker.json
+++ b/src/test/data/JsonSerializableFinanceTrackerTest/typicalRecordsFinanceTracker.json
@@ -2,43 +2,43 @@
   "_comment": "FinanceTracker saves file which contains the same Record values as in TypicalRecords#getTypicalFinanceTracker()",
   "records" : [ {
     "name" : "Alice Pauline",
-    "amount" : "120.30",
+    "amount" : "$120.30",
     "date" : "12/02/2017",
     "description": "",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
-    "amount" : "119",
+    "amount" : "$119",
     "date" : "12/02/2015",
     "description": "",
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
-    "amount" : "130.45",
+    "amount" : "$130.45",
     "date" : "12/05/2017",
     "description": "",
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
-    "amount" : "129",
+    "amount" : "$129",
     "date" : "12/02/2007",
     "description": "",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
-    "amount" : "150",
+    "amount" : "$150",
     "date" : "12/12/2017",
     "description": "",
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
-    "amount" : "520",
+    "amount" : "$520",
     "date" : "02/02/2017",
     "description": "",
     "tagged" : [ ]
   }, {
     "name" : "George Best",
-    "amount" : "128.90",
+    "amount" : "$128.90",
     "date" : "12/02/2027",
     "description": "",
     "tagged" : [ ]

--- a/src/test/java/seedu/finance/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/finance/logic/commands/CommandTestUtil.java
@@ -46,7 +46,7 @@ public class CommandTestUtil {
     public static final String CATEGORY_DESC_HUSBAND = " " + PREFIX_CATEGORY + VALID_CATEGORY_HUSBAND;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
-    public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "42"; // '*' not allowed in amount
+    public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "42"; // did not start with '$'
     public static final String INVALID_DATE_DESC =
             " " + PREFIX_DATE + "29/29/2019"; // invalid date not allowed in dates
     public static final String INVALID_CATEGORY_DESC = " " + PREFIX_CATEGORY

--- a/src/test/java/seedu/finance/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/finance/logic/commands/CommandTestUtil.java
@@ -28,7 +28,7 @@ public class CommandTestUtil {
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_AMOUNT_AMY = "312";
-    public static final String VALID_AMOUNT_BOB = "123";
+    public static final String VALID_AMOUNT_BOB = "123.23";
     public static final String VALID_DATE_AMY = "12/01/2005";
     public static final String VALID_DATE_BOB = "23/04/2014";
     public static final String VALID_CATEGORY_HUSBAND = "husband";
@@ -46,7 +46,7 @@ public class CommandTestUtil {
     public static final String CATEGORY_DESC_HUSBAND = " " + PREFIX_CATEGORY + VALID_CATEGORY_HUSBAND;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
-    public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "*2"; // "*" not allowed in amounts
+    public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "*2"; // '*' not allowed in ammount
     public static final String INVALID_DATE_DESC =
             " " + PREFIX_DATE + "29/29/2019"; // invalid date not allowed in dates
     public static final String INVALID_CATEGORY_DESC = " " + PREFIX_CATEGORY

--- a/src/test/java/seedu/finance/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/finance/logic/commands/CommandTestUtil.java
@@ -27,8 +27,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_AMOUNT_AMY = "312";
-    public static final String VALID_AMOUNT_BOB = "123.23";
+    public static final String VALID_AMOUNT_AMY = "$312";
+    public static final String VALID_AMOUNT_BOB = "$123.23";
     public static final String VALID_DATE_AMY = "12/01/2005";
     public static final String VALID_DATE_BOB = "23/04/2014";
     public static final String VALID_CATEGORY_HUSBAND = "husband";
@@ -46,7 +46,7 @@ public class CommandTestUtil {
     public static final String CATEGORY_DESC_HUSBAND = " " + PREFIX_CATEGORY + VALID_CATEGORY_HUSBAND;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
-    public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "*2"; // '*' not allowed in ammount
+    public static final String INVALID_AMOUNT_DESC = " " + PREFIX_AMOUNT + "42"; // '*' not allowed in amount
     public static final String INVALID_DATE_DESC =
             " " + PREFIX_DATE + "29/29/2019"; // invalid date not allowed in dates
     public static final String INVALID_CATEGORY_DESC = " " + PREFIX_CATEGORY

--- a/src/test/java/seedu/finance/logic/commands/IncreaseCommandTest.java
+++ b/src/test/java/seedu/finance/logic/commands/IncreaseCommandTest.java
@@ -25,7 +25,7 @@ public class IncreaseCommandTest {
 
     @Test
     public void execute() {
-        final Amount amount = new Amount("123");
+        final Amount amount = new Amount("$123.30");
         assertCommandFailure(new IncreaseCommand(amount), model, new CommandHistory(),
                 String.format(MESSAGE_ARGUMENTS, amount));
     }
@@ -35,7 +35,7 @@ public class IncreaseCommandTest {
         final IncreaseCommand standardCommand = new IncreaseCommand(new Amount(VALID_AMOUNT_AMY));
 
         // same values -> returns true
-        IncreaseCommand commandWithSameValues = new IncreaseCommand(new Amount("312"));
+        IncreaseCommand commandWithSameValues = new IncreaseCommand(new Amount("$312"));
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true

--- a/src/test/java/seedu/finance/logic/parser/FinanceTrackerParserTest.java
+++ b/src/test/java/seedu/finance/logic/parser/FinanceTrackerParserTest.java
@@ -176,7 +176,7 @@ public class FinanceTrackerParserTest {
 
     @Test
     public void parseCommand_increase() throws Exception {
-        assertTrue((parser.parseCommand(IncreaseCommand.COMMAND_WORD + " " + PREFIX_AMOUNT + "123")
+        assertTrue((parser.parseCommand(IncreaseCommand.COMMAND_WORD + " " + PREFIX_AMOUNT + "$123")
                 instanceof IncreaseCommand));
     }
 

--- a/src/test/java/seedu/finance/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/finance/logic/parser/ParserUtilTest.java
@@ -23,12 +23,12 @@ import seedu.finance.testutil.Assert;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_AMOUNT = "$1";
+    private static final String INVALID_AMOUNT = "1";
     private static final String INVALID_DATE = "1/30/5999";
     private static final String INVALID_CATEGORY = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_AMOUNT = "123";
+    private static final String VALID_AMOUNT = "$123";
     private static final String VALID_DATE = "12/02/2009";
     private static final String VALID_CATEGORY_1 = "friend";
     private static final String VALID_CATEGORY_2 = "neighbour";

--- a/src/test/java/seedu/finance/model/record/AmountTest.java
+++ b/src/test/java/seedu/finance/model/record/AmountTest.java
@@ -16,7 +16,7 @@ public class AmountTest {
 
     @Test
     public void constructor_invalidAmount_throwsIllegalArgumentException() {
-        String invalidAmount = "$1";
+        String invalidAmount = "1";
         Assert.assertThrows(IllegalArgumentException.class, () -> new Amount(invalidAmount));
     }
 
@@ -30,9 +30,9 @@ public class AmountTest {
         assertFalse(Amount.isValidAmount(" ")); // spaces only
         assertFalse(Amount.isValidAmount("123.3435")); //2 dp only
         // valid amounts
-        assertTrue(Amount.isValidAmount("123"));
-        assertTrue(Amount.isValidAmount("123.24")); // 1 dp only
-        assertTrue(Amount.isValidAmount("1")); // one character
-        assertTrue(Amount.isValidAmount("2147483648.50")); // long amount
+        assertTrue(Amount.isValidAmount("$123"));
+        assertTrue(Amount.isValidAmount("$123.24")); // 1 dp only
+        assertTrue(Amount.isValidAmount("$1")); // one character
+        assertTrue(Amount.isValidAmount("$2147483648.50")); // long amount
     }
 }

--- a/src/test/java/seedu/finance/model/record/AmountTest.java
+++ b/src/test/java/seedu/finance/model/record/AmountTest.java
@@ -28,9 +28,10 @@ public class AmountTest {
         // invalid amounts
         assertFalse(Amount.isValidAmount("")); // empty string
         assertFalse(Amount.isValidAmount(" ")); // spaces only
-
+        assertFalse(Amount.isValidAmount("123.3435")); //2 dp only
         // valid amounts
         assertTrue(Amount.isValidAmount("123"));
+        assertTrue(Amount.isValidAmount("123.24")); // 1 dp only
         assertTrue(Amount.isValidAmount("1")); // one character
         assertTrue(Amount.isValidAmount("2147483648.50")); // long amount
     }

--- a/src/test/java/seedu/finance/model/record/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/finance/model/record/NameContainsKeywordsPredicateTest.java
@@ -68,8 +68,8 @@ public class NameContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new RecordBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and finance, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "27/08/2014"));
-        assertFalse(predicate.test(new RecordBuilder().withName("Alice").withAmount("12345")
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("$12345", "27/08/2014"));
+        assertFalse(predicate.test(new RecordBuilder().withName("Alice").withAmount("$12345")
                 .withDate("27/08/2014").build()));
     }
 }

--- a/src/test/java/seedu/finance/storage/JsonAdaptedRecordTest.java
+++ b/src/test/java/seedu/finance/storage/JsonAdaptedRecordTest.java
@@ -18,7 +18,7 @@ import seedu.finance.testutil.Assert;
 
 public class JsonAdaptedRecordTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_AMOUNT = "$1";
+    private static final String INVALID_AMOUNT = "1";
     private static final String INVALID_DATE = "59/59/2109";
     private static final String INVALID_CATEGORY = "#friend";
 

--- a/src/test/java/seedu/finance/testutil/RecordBuilder.java
+++ b/src/test/java/seedu/finance/testutil/RecordBuilder.java
@@ -17,7 +17,7 @@ import seedu.finance.model.util.SampleDataUtil;
 public class RecordBuilder {
 
     public static final String DEFAULT_NAME = "Alice Pauline";
-    public static final String DEFAULT_AMOUNT = "12";
+    public static final String DEFAULT_AMOUNT = "$12";
     public static final String DEFAULT_DATE = "12/12/2019";
     public static final String DEFAULT_DESCRIPTION = "";
 

--- a/src/test/java/seedu/finance/testutil/TypicalRecords.java
+++ b/src/test/java/seedu/finance/testutil/TypicalRecords.java
@@ -22,25 +22,25 @@ import seedu.finance.model.record.Record;
 public class TypicalRecords {
 
     public static final Record ALICE = new RecordBuilder().withName("Alice Pauline")
-            .withAmount("120.30").withDate("12/02/2017").withCategories("friends").build();
+            .withAmount("$120.30").withDate("12/02/2017").withCategories("friends").build();
     public static final Record BENSON = new RecordBuilder().withName("Benson Meier")
-            .withAmount("119").withDate("12/02/2015").withCategories("owesMoney", "friends").build();
+            .withAmount("$119").withDate("12/02/2015").withCategories("owesMoney", "friends").build();
     public static final Record CARL = new RecordBuilder().withName("Carl Kurz")
-            .withAmount("130.45").withDate("12/05/2017").build();
+            .withAmount("$130.45").withDate("12/05/2017").build();
     public static final Record DANIEL = new RecordBuilder().withName("Daniel Meier")
-            .withAmount("129").withDate("12/02/2007").withCategories("friends").build();
+            .withAmount("$129").withDate("12/02/2007").withCategories("friends").build();
     public static final Record ELLE = new RecordBuilder().withName("Elle Meyer")
-            .withAmount("150").withDate("12/12/2017").build();
+            .withAmount("$150").withDate("12/12/2017").build();
     public static final Record FIONA = new RecordBuilder().withName("Fiona Kunz")
-            .withAmount("520").withDate("02/02/2017").build();
+            .withAmount("$520").withDate("02/02/2017").build();
     public static final Record GEORGE = new RecordBuilder().withName("George Best")
-            .withAmount("128.90").withDate("12/02/2027").build();
+            .withAmount("$128.90").withDate("12/02/2027").build();
 
     // Manually added
     public static final Record HOON = new RecordBuilder().withName("Hoon Meier")
-            .withAmount("720").withDate("12/07/2017").build();
+            .withAmount("$720").withDate("12/07/2017").build();
     public static final Record IDA = new RecordBuilder().withName("Ida Mueller")
-            .withAmount("129").withDate("12/01/2017").build();
+            .withAmount("$129").withDate("12/01/2017").build();
 
     // Manually added - Record's details found in {@code CommandTestUtil}
     public static final Record AMY = new RecordBuilder().withName(VALID_NAME_AMY).withAmount(VALID_AMOUNT_AMY)

--- a/src/test/java/seedu/finance/testutil/TypicalRecords.java
+++ b/src/test/java/seedu/finance/testutil/TypicalRecords.java
@@ -22,11 +22,11 @@ import seedu.finance.model.record.Record;
 public class TypicalRecords {
 
     public static final Record ALICE = new RecordBuilder().withName("Alice Pauline")
-            .withAmount("120").withDate("12/02/2017").withCategories("friends").build();
+            .withAmount("120.30").withDate("12/02/2017").withCategories("friends").build();
     public static final Record BENSON = new RecordBuilder().withName("Benson Meier")
             .withAmount("119").withDate("12/02/2015").withCategories("owesMoney", "friends").build();
     public static final Record CARL = new RecordBuilder().withName("Carl Kurz")
-            .withAmount("130").withDate("12/05/2017").build();
+            .withAmount("130.45").withDate("12/05/2017").build();
     public static final Record DANIEL = new RecordBuilder().withName("Daniel Meier")
             .withAmount("129").withDate("12/02/2007").withCategories("friends").build();
     public static final Record ELLE = new RecordBuilder().withName("Elle Meyer")
@@ -34,7 +34,7 @@ public class TypicalRecords {
     public static final Record FIONA = new RecordBuilder().withName("Fiona Kunz")
             .withAmount("520").withDate("02/02/2017").build();
     public static final Record GEORGE = new RecordBuilder().withName("George Best")
-            .withAmount("128").withDate("12/02/2027").build();
+            .withAmount("128.90").withDate("12/02/2027").build();
 
     // Manually added
     public static final Record HOON = new RecordBuilder().withName("Hoon Meier")

--- a/src/test/java/seedu/finance/ui/RecordListPanelTest.java
+++ b/src/test/java/seedu/finance/ui/RecordListPanelTest.java
@@ -80,7 +80,7 @@ public class RecordListPanelTest extends GuiUnitTest {
         ObservableList<Record> backingList = FXCollections.observableArrayList();
         for (int i = 0; i < recordCount; i++) {
             Name name = new Name(i + "a");
-            Amount amount = new Amount("123");
+            Amount amount = new Amount("$123");
             Date date = new Date("12/12/2018");
             Description description = new Description ("");
             Record record = new Record(name, amount, date, description, Collections.emptySet());

--- a/src/test/java/systemtests/SpendCommandSystemTest.java
+++ b/src/test/java/systemtests/SpendCommandSystemTest.java
@@ -77,7 +77,7 @@ public class SpendCommandSystemTest extends FinanceTrackerSystemTest {
         /* Case: add a record with all fields same as another record in the finance tracker except amount and date
          * -> added
          */
-        toSpend = new RecordBuilder(AMY).withAmount("999").withDate("01/01/2001").build();
+        toSpend = new RecordBuilder(AMY).withAmount("$999").withDate("01/01/2001").build();
         command = RecordUtil.getSpendCommand(toSpend);
         assertCommandSuccess(command, toSpend);
 


### PR DESCRIPTION
Changed `Amount` class to ensure that each amount:
- Starts with a `$` sign.
- Can take in either 2 decimal place or no decimals at all.

Updated test cases based on above-mentioned changes.