### PR TITLE
Updated Spend Command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -139,13 +139,13 @@ You can keep track of how much you have spent by adding an expense entry to _In-
 
 *Alias*: `add`
 
-*Format*: `spend n/NAME $/AMOUNT d/DATE c/CATEGORY`
+*Format*: `spend n/NAME $/AMOUNT d/DATE c/CATEGORY r/DESCRIPTION`
 
 ****
 *Examples*:
 
-* `spend n/cake $/5.50 d/15/03/2019 c/Food`
-* `spend n/movie $/10 d/16/03/2019 c/Entertainment`
+* `spend n/cake $/5.50 d/15/03/2019 c/Food r/Birthday celebration`
+* `spend n/movie $/10 d/16/03/2019 c/Entertainment r/Avengers: End Game`
 ****
 
 [NOTE]
@@ -535,7 +535,8 @@ _In-Credit-Ble_  aims to support multi-currency transactions in `v2.0`.
 [width="59%",cols="22%,<23%,<25%,<30%",options="header",]
 |=======================================================================
 | Command | Command Format | Alias | Example
-| Add expense | `spend n/NAME $/AMOUNT [d/DATE] [c/CATEGORY] ...` | `add` | `spend n/movie $/10 d/16/03/2019 c/Entertainment`
+| Add expense | `spend n/NAME $/AMOUNT [d/DATE] [c/CATEGORY] ... [r/Description]` | `add` | `spend n/movie $/10
+  d/16/03/2019 c/Entertainment r/Avengers: Endgame`
 | Add a description to an entry | `description INDEX r/DESCRIPTION` | `descr` | `description 1 d/Father's birthday present`
 | Edit an entry | `edit INDEX [n/NAME] [$/AMOUNT] [d/DATE] [c/CATEGORY]` | `e` | `edit 1 n/burger c/Food`
 | Select an entry | `select INDEX` | `s`, `sel` | `select 3`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -158,6 +158,7 @@ category and will be shown with the first character in uppercase and the rest of
 in lowercase (in the above example, it will be shown as `Clothes`)
 * Category name supplied must be https://en.wikipedia.org/wiki/Alphanumeric[alphanumeric]
 and cannot contain special characters such as `:<>;\/|?~^%$#@`
+* If no date is inputted, current local date will be used instead.
 ====
 // end::spend[]
 
@@ -534,8 +535,8 @@ _In-Credit-Ble_  aims to support multi-currency transactions in `v2.0`.
 [width="59%",cols="22%,<23%,<25%,<30%",options="header",]
 |=======================================================================
 | Command | Command Format | Alias | Example
-| Add expense | `spend n/NAME $/AMOUNT d/DATE [c/CATEGORY] ...` | `add` | `spend n/movie $/10 d/16/03/2019 c/Entertainment`
-| Add a description to an entry | `description INDEX d/DESCRIPTION` | `descr` | `description 1 d/Father's birthday present`
+| Add expense | `spend n/NAME $/AMOUNT [d/DATE] [c/CATEGORY] ...` | `add` | `spend n/movie $/10 d/16/03/2019 c/Entertainment`
+| Add a description to an entry | `description INDEX r/DESCRIPTION` | `descr` | `description 1 d/Father's birthday present`
 | Edit an entry | `edit INDEX [n/NAME] [$/AMOUNT] [d/DATE] [c/CATEGORY]` | `e` | `edit 1 n/burger c/Food`
 | Select an entry | `select INDEX` | `s`, `sel` | `select 3`
 | Delete an entry | `delete INDEX` | `d`, `del` | `delete 2`

--- a/src/main/java/seedu/finance/logic/commands/SpendCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SpendCommand.java
@@ -27,6 +27,7 @@ public class SpendCommand extends Command {
             + PREFIX_DATE + "DATE "
             + PREFIX_CATEGORY + "CATEGORY\n"
             + "Note that each record should only have one category.\n"
+            + "If date is not inputted, local date will be used.\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_AMOUNT + "123.23 "

--- a/src/main/java/seedu/finance/logic/commands/SpendCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SpendCommand.java
@@ -2,9 +2,9 @@ package seedu.finance.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.finance.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.finance.logic.CommandHistory;

--- a/src/main/java/seedu/finance/logic/commands/SpendCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SpendCommand.java
@@ -1,7 +1,11 @@
 package seedu.finance.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.finance.logic.parser.CliSyntax.*;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_AMOUNT;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_CATEGORY;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.finance.logic.CommandHistory;
 import seedu.finance.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/finance/logic/commands/SpendCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SpendCommand.java
@@ -1,10 +1,7 @@
 package seedu.finance.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.finance.logic.parser.CliSyntax.PREFIX_AMOUNT;
-import static seedu.finance.logic.parser.CliSyntax.PREFIX_CATEGORY;
-import static seedu.finance.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.finance.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.finance.logic.parser.CliSyntax.*;
 
 import seedu.finance.logic.CommandHistory;
 import seedu.finance.logic.commands.exceptions.CommandException;
@@ -26,13 +23,15 @@ public class SpendCommand extends Command {
             + PREFIX_AMOUNT + "AMOUNT "
             + PREFIX_DATE + "DATE "
             + PREFIX_CATEGORY + "CATEGORY\n"
+            + PREFIX_DESCRIPTION + "DESCRIPTION\n"
             + "Note that each record should only have one category.\n"
             + "If date is not inputted, local date will be used.\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_AMOUNT + "123.23 "
             + PREFIX_DATE + "12/02/2002 "
-            + PREFIX_CATEGORY + "Food ";
+            + PREFIX_CATEGORY + "Food "
+            + PREFIX_DESCRIPTION + "Lunch with friends ";
 
     public static final String MESSAGE_SUCCESS = "New record added: %1$s";
     public static final String MESSAGE_SUCCESS_EXCEED_BUDGET = "Your spending in %s "

--- a/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
+++ b/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.finance.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import seedu.finance.logic.commands.SpendCommand;
@@ -31,14 +32,19 @@ public class SpendCommandParser implements Parser<SpendCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_AMOUNT, PREFIX_DATE, PREFIX_CATEGORY);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_AMOUNT, PREFIX_DATE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_AMOUNT)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SpendCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Amount amount = ParserUtil.parseAmount(argMultimap.getValue(PREFIX_AMOUNT).get());
-        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        Date date;
+        if (arePrefixesPresent(argMultimap, PREFIX_DATE)) {
+            date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        } else {
+            date = new Date(LocalDate.now());
+        }
         Description description = new Description("");
         Category category = ParserUtil.parseCategory(argMultimap.getValue(PREFIX_CATEGORY).get());
 

--- a/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
+++ b/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
@@ -5,6 +5,7 @@ import static seedu.finance.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;
@@ -30,7 +31,8 @@ public class SpendCommandParser implements Parser<SpendCommand> {
      */
     public SpendCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_AMOUNT, PREFIX_DATE, PREFIX_CATEGORY);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_AMOUNT, PREFIX_DATE, PREFIX_CATEGORY,
+                        PREFIX_DESCRIPTION);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_AMOUNT)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -45,7 +47,7 @@ public class SpendCommandParser implements Parser<SpendCommand> {
         } else {
             date = new Date(LocalDate.now());
         }
-        Description description = new Description("");
+        Description description = new Description(argMultimap.getValue(PREFIX_DESCRIPTION).get().trim());
         Category category = ParserUtil.parseCategory(argMultimap.getValue(PREFIX_CATEGORY).get());
 
         Record record = new Record(name, amount, date, description, category);

--- a/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
+++ b/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
@@ -4,8 +4,8 @@ import static seedu.finance.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_CATEGORY;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.finance.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.finance.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.finance.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.time.LocalDate;
 import java.util.stream.Stream;

--- a/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
+++ b/src/main/java/seedu/finance/logic/parser/SpendCommandParser.java
@@ -47,7 +47,11 @@ public class SpendCommandParser implements Parser<SpendCommand> {
         } else {
             date = new Date(LocalDate.now());
         }
-        Description description = new Description(argMultimap.getValue(PREFIX_DESCRIPTION).get().trim());
+        Description description = new Description("");
+        if (arePrefixesPresent(argMultimap, PREFIX_DESCRIPTION)) {
+            description = new Description(argMultimap.getValue(PREFIX_DESCRIPTION).get().trim());
+        }
+
         Category category = ParserUtil.parseCategory(argMultimap.getValue(PREFIX_CATEGORY).get());
 
         Record record = new Record(name, amount, date, description, category);

--- a/src/main/java/seedu/finance/model/record/Date.java
+++ b/src/main/java/seedu/finance/model/record/Date.java
@@ -25,6 +25,7 @@ public class Date {
      */
     public Date(String date) {
         requireNonNull(date);
+
         checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
 
         String[] parsedDate = date.split("/");
@@ -32,6 +33,15 @@ public class Date {
         int month = Integer.parseInt(parsedDate[1]);
         int day = Integer.parseInt(parsedDate[0]);
         this.setDate(year, month, day);
+    }
+
+    /**
+     * Constructs a (@code Date).
+     *
+     * @param date A local date object.
+     */
+    public Date(LocalDate date) {
+        this.date = date;
     }
 
     /**

--- a/src/test/java/seedu/finance/model/record/DateTest.java
+++ b/src/test/java/seedu/finance/model/record/DateTest.java
@@ -11,7 +11,8 @@ public class DateTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> new Date(null));
+        String test = null;
+        Assert.assertThrows(NullPointerException.class, () -> new Date(test));
     }
 
     @Test


### PR DESCRIPTION
- Spend command now takes in optional description field using the prefix /r.
- If date is not specified for the spend command, current date is used instead.
- Changes reflected in user guide. 