### PR TITLE
Enhance sort command to allow -asc and -desc

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -300,30 +300,38 @@ spent on all the results of the search will also be shown.
 
 You can choose to sort the list of entries by name, amount, date or category.
 
-*Format*: `sort FLAG`
+*Format*: `sort FLAG [ORDER]`
 
 [NOTE]
 ====
 * `FLAG` here refers to either `-name`, `-amount, `-date` or `-cat`.
 * Only one flag should be provided.
+
+* `[ORDER]` refers to either `-asc` or `-desc`.
+* `[Order]` is optional. If not supplied, default ordering is implied.
 ====
 
 ****
-*Examples*:
+*Examples (default ordering)*:
 
 * `sort -name`: +
-By default, sorts the list of records by name in lexicographical order
+Sorts the list of records by name in lexicographical order (ascending order)
 * `sort -amount`: +
-By default, sorts the list of records by amount from largest to smallest
+Sorts the list of records by amount from largest to smallest (descending order)
 * `sort -date`: +
-By default, sorts the list of records by date with the latest at the top
+Sorts the list of records by date with the latest at the top (descending order)
 * `sort -cat`: +
-By default, sorts the list of records by category
+Sorts the list of records by category in lexicographical order (ascending order)
+
+*More examples*:
+
+* `sort -name -desc`: +
+Sorts list of records by name in reverse lexicographical order.
 ****
 
 [TIP]
-To sort the list in the reverse order, use the `reverse` command! +
-* `sort -name` +
+To sort the list conveniently in the reverse order, use the `reverse` command! +
+`sort -name` +
 `reverse` +
 List will be sorted by name in reverse lexicographical order.
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -308,7 +308,7 @@ You can choose to sort the list of entries by name, amount, date or category.
 * Only one flag should be provided.
 
 * `[ORDER]` refers to either `-asc` or `-desc`.
-* `[Order]` is optional. If not supplied, default ordering is implied.
+* `[ORDER]` is optional. If not supplied, default ordering is implied.
 ====
 
 ****

--- a/src/main/java/seedu/finance/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SortCommand.java
@@ -37,7 +37,7 @@ public class SortCommand extends Command {
             + COMMAND_FLAG_DESCENDING + ": Descending order\n"
             + "Example: \n"
             + COMMAND_WORD + " " + COMMAND_FLAG_NAME + "\n"
-            + COMMAND_WORD + " " + COMMAND_FLAG_NAME + " -desc" + "\n"
+            + COMMAND_WORD + " " + COMMAND_FLAG_NAME + " " + COMMAND_FLAG_DESCENDING + "\n"
             + "Tip: Use the reverse command to reverse the list!\n";
 
     public static final String MESSAGE_SUCCESS = "List is sorted.";

--- a/src/main/java/seedu/finance/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SortCommand.java
@@ -2,8 +2,10 @@ package seedu.finance.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_AMOUNT;
+import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_ASCENDING;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_CATEGORY;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_DATE;
+import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_DESCENDING;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_NAME;
 
 import java.util.Comparator;
@@ -23,17 +25,22 @@ public class SortCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts the records in the list "
             + "either by name, amount, date or category based on the selected flag.\n"
-            + "Parameters: FLAG \n"
+            + "Parameters: FLAG [ORDER]\n"
+            + "[ORDER] is optional. If not supplied, default ordering is implied.\n"
             + "Flags: \n"
-            + COMMAND_FLAG_NAME + ": Sort records by name in lexicographical order\n"
-            + COMMAND_FLAG_AMOUNT + ": Sort records by amount in descending order\n"
-            + COMMAND_FLAG_DATE + ": Sort records by date from most recent to least recent\n"
-            + COMMAND_FLAG_CATEGORY + ": Sort records by category in lexicographical order\n"
-            + "Example: " + COMMAND_WORD + " " + COMMAND_FLAG_NAME + "\n"
-            + "Tip: To sort the records in the reverse order, use the reverse command!\n";
+            + COMMAND_FLAG_NAME + ": Sort records by name (default: lexicographical order)\n"
+            + COMMAND_FLAG_AMOUNT + ": Sort records by amount (default: descending order)\n"
+            + COMMAND_FLAG_DATE + ": Sort records by date (default: descending order ie. most recent to least recent)\n"
+            + COMMAND_FLAG_CATEGORY + ": Sort records by category (default: lexicographical order)\n"
+            + "Order: \n"
+            + COMMAND_FLAG_ASCENDING + ": Ascending order\n"
+            + COMMAND_FLAG_DESCENDING + ": Descending order\n"
+            + "Example: \n"
+            + COMMAND_WORD + " " + COMMAND_FLAG_NAME + "\n"
+            + COMMAND_WORD + " " + COMMAND_FLAG_NAME + " -desc" + "\n"
+            + "Tip: Use the reverse command to reverse the list!\n";
 
     public static final String MESSAGE_SUCCESS = "List is sorted.";
-    public static final String MESSAGE_NOT_SORTED = "Only one flag should be provided.";
 
     private final Comparator<Record> comparator;
 

--- a/src/main/java/seedu/finance/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/finance/logic/parser/CliSyntax.java
@@ -20,4 +20,8 @@ public class CliSyntax {
     public static final CommandFlag COMMAND_FLAG_CATEGORY = new CommandFlag("-cat");
     public static final CommandFlag COMMAND_FLAG_AMOUNT = new CommandFlag("-amount");
     public static final CommandFlag COMMAND_FLAG_DATE = new CommandFlag("-date");
+
+    public static final CommandFlag COMMAND_FLAG_ASCENDING = new CommandFlag("-asc");
+    public static final CommandFlag COMMAND_FLAG_DESCENDING = new CommandFlag("-desc");
+
 }

--- a/src/test/java/seedu/finance/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/finance/logic/commands/SortCommandTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import seedu.finance.logic.CommandHistory;
 import seedu.finance.logic.commands.exceptions.CommandException;
 import seedu.finance.logic.parser.comparator.RecordAmountComparator;
+import seedu.finance.logic.parser.comparator.RecordCategoryComparator;
 import seedu.finance.logic.parser.comparator.RecordDateComparator;
 import seedu.finance.logic.parser.comparator.RecordNameComparator;
 import seedu.finance.model.FinanceTracker;
@@ -63,8 +64,6 @@ public class SortCommandTest {
 
     }
 
-    // TODO: Failed Test; need to update
-    /*
     @Test
     public void execute_sortByCategory_success() {
         Model expectedModel = new ModelManager(new FinanceTracker(model.getFinanceTracker()), new UserPrefs());
@@ -73,8 +72,8 @@ public class SortCommandTest {
         assertCommandSuccess(new SortCommand(new RecordCategoryComparator()), model, commandHistory,
                 SortCommand.MESSAGE_SUCCESS, expectedModel);
 
-        assertEquals(Arrays.asList(CAP, EARRINGS, FRUITS, GIFT, BANANA, DONUT, APPLE), model.getFilteredRecordList());
-    }*/
+        assertEquals(Arrays.asList(EARRINGS, CAP, BANANA, DONUT, FRUITS, GIFT, APPLE), model.getFilteredRecordList());
+    }
 
     @Test
     public void executeUndoRedo_listSortedByAmount_success() throws CommandException {
@@ -99,8 +98,4 @@ public class SortCommandTest {
         assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
         assertEquals(Arrays.asList(GIFT, FRUITS, CAP, EARRINGS, BANANA, APPLE, DONUT), model.getFilteredRecordList());
     }
-
-    // redo undo tests
-    // reverse
-
 }

--- a/src/test/java/seedu/finance/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/finance/logic/parser/SortCommandParserTest.java
@@ -1,8 +1,11 @@
 package seedu.finance.logic.parser;
 
+import static seedu.finance.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_AMOUNT;
+import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_ASCENDING;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_CATEGORY;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_DATE;
+import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_DESCENDING;
 import static seedu.finance.logic.parser.CliSyntax.COMMAND_FLAG_NAME;
 import static seedu.finance.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.finance.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -21,7 +24,8 @@ public class SortCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, " ", SortCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SortCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -30,15 +34,35 @@ public class SortCommandParserTest {
         assertParseSuccess(parser, COMMAND_FLAG_AMOUNT.getFlag(), new SortCommand(new RecordAmountComparator()));
         assertParseSuccess(parser, COMMAND_FLAG_DATE.getFlag(), new SortCommand(new RecordDateComparator()));
         assertParseSuccess(parser, COMMAND_FLAG_CATEGORY.getFlag(), new SortCommand(new RecordCategoryComparator()));
-    }
 
-    @Test
-    public void parse_multipleFlags_throwsParseException() {
-        assertParseFailure(parser, COMMAND_FLAG_NAME + " " + COMMAND_FLAG_AMOUNT, SortCommand.MESSAGE_NOT_SORTED);
+        assertParseSuccess(parser, COMMAND_FLAG_NAME.getFlag() + " " + COMMAND_FLAG_ASCENDING,
+                new SortCommand(new RecordNameComparator()));
+        assertParseSuccess(parser, COMMAND_FLAG_AMOUNT.getFlag() + " " + COMMAND_FLAG_ASCENDING,
+                new SortCommand(new RecordAmountComparator()));
+        assertParseSuccess(parser, COMMAND_FLAG_DATE.getFlag() + " " + COMMAND_FLAG_ASCENDING,
+                new SortCommand(new RecordDateComparator()));
+        assertParseSuccess(parser, COMMAND_FLAG_CATEGORY.getFlag() + " " + COMMAND_FLAG_ASCENDING,
+                new SortCommand(new RecordCategoryComparator()));
+
+        assertParseSuccess(parser, COMMAND_FLAG_NAME.getFlag() + " " + COMMAND_FLAG_DESCENDING,
+                new SortCommand(new RecordNameComparator()));
+        assertParseSuccess(parser, COMMAND_FLAG_AMOUNT.getFlag() + " " + COMMAND_FLAG_DESCENDING,
+                new SortCommand(new RecordAmountComparator()));
+        assertParseSuccess(parser, COMMAND_FLAG_DATE.getFlag() + " " + COMMAND_FLAG_DESCENDING,
+                new SortCommand(new RecordDateComparator()));
+        assertParseSuccess(parser, COMMAND_FLAG_CATEGORY.getFlag() + " " + COMMAND_FLAG_DESCENDING,
+                new SortCommand(new RecordCategoryComparator()));
+
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "-description", SortCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, " -description", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " " + COMMAND_FLAG_NAME + " -a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, " -description " + COMMAND_FLAG_ASCENDING,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+
     }
 }


### PR DESCRIPTION
commands:
sort FLAG [ORDER]

[ORDER] is optional. Default ordering is implied when users don't specify.

FLAG: -name, -amount, -date, -cat
ORDER: -asc, -desc

command only looks at first two arguments after sort, ignores the rest (the back stuff)


