### PR TITLE
Resolved month bug

### DIFF
--- a/src/main/java/seedu/finance/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/finance/logic/commands/SummaryCommand.java
@@ -125,7 +125,7 @@ public class SummaryCommand extends Command {
         if (period == SummaryPeriod.DAY) {
             date = LocalDate.now().minusDays((long) periodAmount);
         } else {
-            date = LocalDate.now().minusDays((long) periodAmount);
+            date = LocalDate.now().minusMonths((long) periodAmount);
         }
         return e -> e.getDate().isAfter(date);
     }


### PR DESCRIPTION
Edited `SummaryCommand.java` as previously had a bug that did not display the correct list of records when the `month` period parameter was specified